### PR TITLE
Add special cases for functionOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/
+stack.yaml.lock
 *~
 dist-newstyle/
 dist/

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.19
+resolver: lts-16.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This doesn't quite get rid of the need for some special case checking in `disco`, because of the issue discussed at #1.  I don't think it makes sense to try to fix that here.